### PR TITLE
Expose and use the proposed open_karto parameter, minimum time interval

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -169,6 +169,10 @@ SlamKarto::SlamKarto() :
   if(private_nh_.getParam("use_scan_barycenter", use_scan_barycenter))
     mapper_->setParamUseScanBarycenter(use_scan_barycenter);
 
+  double minimum_time_interval;
+  if(private_nh_.getParam("minimum_time_interval", minimum_time_interval))
+    mapper_->setParamMinimumTimeInterval(minimum_time_interval);
+
   double minimum_travel_distance;
   if(private_nh_.getParam("minimum_travel_distance", minimum_travel_distance))
     mapper_->setParamMinimumTravelDistance(minimum_travel_distance);

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -164,7 +164,7 @@ SlamKarto::SlamKarto() :
   bool use_scan_matching;
   if(private_nh_.getParam("use_scan_matching", use_scan_matching))
     mapper_->setParamUseScanMatching(use_scan_matching);
-  
+
   bool use_scan_barycenter;
   if(private_nh_.getParam("use_scan_barycenter", use_scan_barycenter))
     mapper_->setParamUseScanBarycenter(use_scan_barycenter);
@@ -386,7 +386,7 @@ SlamKarto::getLaser(const sensor_msgs::LaserScan::ConstPtr& scan)
     // Create a laser range finder device and copy in data from the first
     // scan
     std::string name = scan->header.frame_id;
-    karto::LaserRangeFinder* laser = 
+    karto::LaserRangeFinder* laser =
       karto::LaserRangeFinder::CreateLaserRangeFinder(karto::LaserRangeFinder_Custom, karto::Name(name));
     laser->SetOffsetPose(karto::Pose2(laser_pose.getOrigin().x(),
 				      laser_pose.getOrigin().y(),
@@ -427,7 +427,7 @@ SlamKarto::getOdomPose(karto::Pose2& karto_pose, const ros::Time& t)
   }
   double yaw = tf::getYaw(odom_pose.getRotation());
 
-  karto_pose = 
+  karto_pose =
           karto::Pose2(odom_pose.getOrigin().x(),
                        odom_pose.getOrigin().y(),
                        yaw);
@@ -477,7 +477,7 @@ SlamKarto::publishGraphVisualization()
 
   m.action = visualization_msgs::Marker::ADD;
   uint id = 0;
-  for (uint i=0; i<graph.size()/2; i++) 
+  for (uint i=0; i<graph.size()/2; i++)
   {
     m.id = id;
     m.pose.position.x = graph[2*i];
@@ -504,7 +504,7 @@ SlamKarto::publishGraphVisualization()
   }
 
   m.action = visualization_msgs::Marker::DELETE;
-  for (; id < marker_count_; id++) 
+  for (; id < marker_count_; id++)
   {
     m.id = id;
     marray.markers.push_back(visualization_msgs::Marker(m));
@@ -537,14 +537,14 @@ SlamKarto::laserCallback(const sensor_msgs::LaserScan::ConstPtr& scan)
   karto::Pose2 odom_pose;
   if(addScan(laser, scan, odom_pose))
   {
-    ROS_DEBUG("added scan at pose: %.3f %.3f %.3f", 
+    ROS_DEBUG("added scan at pose: %.3f %.3f %.3f",
               odom_pose.GetX(),
               odom_pose.GetY(),
               odom_pose.GetHeading());
 
     publishGraphVisualization();
 
-    if(!got_map_ || 
+    if(!got_map_ ||
        (scan->header.stamp - last_map_update) > map_update_interval_)
     {
       if(updateMap())
@@ -562,7 +562,7 @@ SlamKarto::updateMap()
 {
   boost::mutex::scoped_lock(map_mutex_);
 
-  karto::OccupancyGrid* occ_grid = 
+  karto::OccupancyGrid* occ_grid =
           karto::OccupancyGrid::CreateFromScans(mapper_->GetAllProcessedScans(), resolution_);
 
   if(!occ_grid)
@@ -577,14 +577,14 @@ SlamKarto::updateMap()
     map_.map.info.origin.orientation.y = 0.0;
     map_.map.info.origin.orientation.z = 0.0;
     map_.map.info.origin.orientation.w = 1.0;
-  } 
+  }
 
   // Translate to ROS format
   kt_int32s width = occ_grid->GetWidth();
   kt_int32s height = occ_grid->GetHeight();
   karto::Vector2<kt_double> offset = occ_grid->GetCoordinateConverter()->GetOffset();
 
-  if(map_.map.info.width != (unsigned int) width || 
+  if(map_.map.info.width != (unsigned int) width ||
      map_.map.info.height != (unsigned int) height ||
      map_.map.info.origin.position.x != offset.GetX() ||
      map_.map.info.origin.position.y != offset.GetY())
@@ -598,7 +598,7 @@ SlamKarto::updateMap()
 
   for (kt_int32s y=0; y<height; y++)
   {
-    for (kt_int32s x=0; x<width; x++) 
+    for (kt_int32s x=0; x<width; x++)
     {
       // Getting the value at position x,y
       kt_int8u value = occ_grid->GetValue(karto::Vector2<kt_int32s>(x, y));
@@ -620,7 +620,7 @@ SlamKarto::updateMap()
       }
     }
   }
-  
+
   // Set the header information on the map
   map_.map.header.stamp = ros::Time::now();
   map_.map.header.frame_id = map_frame_;
@@ -635,12 +635,12 @@ SlamKarto::updateMap()
 
 bool
 SlamKarto::addScan(karto::LaserRangeFinder* laser,
-		   const sensor_msgs::LaserScan::ConstPtr& scan, 
+		   const sensor_msgs::LaserScan::ConstPtr& scan,
                    karto::Pose2& karto_pose)
 {
   if(!getOdomPose(karto_pose, scan->header.stamp))
      return false;
-  
+
   // Create a vector of doubles for karto
   std::vector<kt_double> readings;
 
@@ -659,19 +659,20 @@ SlamKarto::addScan(karto::LaserRangeFinder* laser,
       readings.push_back(*it);
     }
   }
-  
+
   // create localized range scan
-  karto::LocalizedRangeScan* range_scan = 
+  karto::LocalizedRangeScan* range_scan =
     new karto::LocalizedRangeScan(laser->GetName(), readings);
   range_scan->SetOdometricPose(karto_pose);
   range_scan->SetCorrectedPose(karto_pose);
+  range_scan->SetTime(scan->header.stamp.toSec());
 
   // Add the localized range scan to the mapper
   bool processed;
   if((processed = mapper_->Process(range_scan)))
   {
     //std::cout << "Pose: " << range_scan->GetOdometricPose() << " Corrected Pose: " << range_scan->GetCorrectedPose() << std::endl;
-    
+
     karto::Pose2 corrected_pose = range_scan->GetCorrectedPose();
 
     // Compute the map->odom transform
@@ -703,7 +704,7 @@ SlamKarto::addScan(karto::LaserRangeFinder* laser,
   return processed;
 }
 
-bool 
+bool
 SlamKarto::mapCallback(nav_msgs::GetMap::Request  &req,
                        nav_msgs::GetMap::Response &res)
 {


### PR DESCRIPTION
This PR is tied to ros-perception/open_karto#11 ⚠️ 

This is a follow-up to the open_karto PR mentioned above. It adds a new ROS param, `minimum_time_interval`, which is used to set the proposed open_karto param `MinimumTimeInterval`. It also passes the laser scan message's time stamp to open_karto enabling it to calculate the time interval between two scans.
