### PR TITLE
adds the minimum_time_interval parameter

### DIFF
--- a/config/mapper_params.yaml
+++ b/config/mapper_params.yaml
@@ -1,6 +1,7 @@
 # General Parameters
 use_scan_matching: true
 use_scan_barycenter: true
+minimum_time_interval: 3600
 minimum_travel_distance: 0.2 
 minimum_travel_heading: 0.174                  #in radians
 scan_buffer_size: 70

--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -169,6 +169,10 @@ SlamKarto::SlamKarto() :
   if(private_nh_.getParam("use_scan_barycenter", use_scan_barycenter))
     mapper_->setParamUseScanBarycenter(use_scan_barycenter);
 
+  double minimum_time_interval;
+  if(private_nh_.getParam("minimum_time_interval", minimum_time_interval))
+    mapper_->setParamMinimumTimeInterval(minimum_time_interval);
+
   double minimum_travel_distance;
   if(private_nh_.getParam("minimum_travel_distance", minimum_travel_distance))
     mapper_->setParamMinimumTravelDistance(minimum_travel_distance);


### PR DESCRIPTION
While filling in the [documentation on wiki.ros.org](http://wiki.ros.org/slam_karto), I noticed the [parameter open_karto::Mapper::MinimumTimeInterval](https://docs.ros.org/melodic/api/open_karto/html/Mapper_8cpp_source.html#l01679) was missing from the ros params provided by the slam_karto node.

This PR adds it in. 