### PR TITLE
Transform tolerance

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -137,7 +137,7 @@ SlamKarto::SlamKarto() :
   map_update_interval_.fromSec(tmp);
  
   double tmp_tol;
-  private_nh_.param("transform_tolerance", tmp_tol, 0.05);
+  private_nh_.param("transform_tolerance", tmp_tol, 0.0);
   transform_tolerance_.fromSec(tmp_tol);
 
   if(!private_nh_.getParam("resolution", resolution_))


### PR DESCRIPTION
This PR solves issue #29 by making use of the tf_expiration value in the timestamp of the map->odom published TF . 

It also adds a transform_tolerance parameter which defaults to 0.05 (the origin default used in the code) .
