### PR TITLE
fix bug for wrong visualization edge marker

### DIFF
--- a/src/slam_karto.cpp
+++ b/src/slam_karto.cpp
@@ -490,7 +490,7 @@ SlamKarto::publishGraphVisualization()
 
   m.action = visualization_msgs::Marker::ADD;
   uint id = 0;
-  for (uint i=0; i<graph.size()/2; i++) 
+  for (uint i=0; i<graph.size()/2; i+=2) 
   {
     m.id = id;
     m.pose.position.x = graph[2*i];
@@ -498,22 +498,24 @@ SlamKarto::publishGraphVisualization()
     marray.markers.push_back(visualization_msgs::Marker(m));
     id++;
 
-    if(i>0)
-    {
-      edge.points.clear();
+    m.pose.position.x = graph[2*(i+1)];
+    m.pose.position.y = graph[2*(i+1)+1];
+    marray.markers.push_back(visualization_msgs::Marker(m));
+    id++;
 
-      geometry_msgs::Point p;
-      p.x = graph[2*(i-1)];
-      p.y = graph[2*(i-1)+1];
-      edge.points.push_back(p);
-      p.x = graph[2*i];
-      p.y = graph[2*i+1];
-      edge.points.push_back(p);
-      edge.id = id;
+    edge.points.clear();
 
-      marray.markers.push_back(visualization_msgs::Marker(edge));
-      id++;
-    }
+    geometry_msgs::Point p;
+    p.x = graph[2*i];
+    p.y = graph[2*i+1];
+    edge.points.push_back(p);
+    p.x = graph[2*(i+1)];
+    p.y = graph[2*(i+1)+1];
+    edge.points.push_back(p);
+    edge.id = id;
+
+    marray.markers.push_back(visualization_msgs::Marker(edge));
+    id++;
   }
 
   m.action = visualization_msgs::Marker::DELETE;


### PR DESCRIPTION
`solver_->getGraph(graph)` in the function `SlamKarto::publishGraphVisualizaition()` return x,y -> x'y' 4 floats per connection.

So, (graphp[0], graph[1]) -> (graph[2], graph[3]), but there should be no connection between (graph[2], graph[3]) and (graph[4], graph[5]). Since for a single robot, (graph[2], graph[3]) and (graph[4], graph[5]) are the same, so the bug will not appear, see graph[2-5] in graph_data.png.

For example two robots will have wrong cross-connections, see wrong_behavior.png. And their corresponding data is shown in graph_data.png, such as graph[32-36]. 

The result of my modified code is displayed in right_behavior.png. 


![graph_data](https://user-images.githubusercontent.com/49157013/87373387-2e53f880-c5bc-11ea-928c-5c8c2b2d07a0.png)
![wrong_behavior](https://user-images.githubusercontent.com/49157013/87373386-2dbb6200-c5bc-11ea-999c-550a2908b1c2.png)
![right_behavior](https://user-images.githubusercontent.com/49157013/87373375-2b590800-c5bc-11ea-8fc3-2bd176a04ce4.png)


